### PR TITLE
Add missing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ boto3>=1.9.187
 python-swiftclient>=3.8.0
 python-keystoneclient>=3.20.0
 celery>=4.4.0
+cryptography>=2.9.2


### PR DESCRIPTION
I get this error when running the container:

```bash
your mercy for graceful operations on workers is 60 seconds
mapped 1239640 bytes (1210 KB) for 16 cores
*** Operational MODE: preforking ***
2020-05-04 19:03:33,070 INFO success: uwsgi entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
Traceback (most recent call last):
  File "./main.py", line 35, in <module>
    heartbeat_config.config["object_storage_auth"],
  File "./heartbeat_db.py", line 132, in init_db
    mysql_db.connect()
  File "/usr/local/lib/python3.7/site-packages/peewee.py", line 3035, in connect
    self._state.set_connection(self._connect())
  File "/usr/local/lib/python3.7/site-packages/peewee.py", line 3933, in _connect
    conn = mysql.connect(db=self.database, **self.connect_params)
  File "/usr/local/lib/python3.7/site-packages/pymysql/__init__.py", line 94, in Connect
    return Connection(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/pymysql/connections.py", line 325, in __init__
    self.connect()
  File "/usr/local/lib/python3.7/site-packages/pymysql/connections.py", line 599, in connect
    self._request_authentication()
  File "/usr/local/lib/python3.7/site-packages/pymysql/connections.py", line 882, in _request_authentication
    auth_packet = _auth.caching_sha2_password_auth(self, auth_packet)
  File "/usr/local/lib/python3.7/site-packages/pymysql/_auth.py", line 264, in caching_sha2_password_auth
    data = sha2_rsa_encrypt(conn.password, conn.salt, conn.server_public_key)
  File "/usr/local/lib/python3.7/site-packages/pymysql/_auth.py", line 142, in sha2_rsa_encrypt
    raise RuntimeError("cryptography is required for sha256_password or caching_sha2_password")
RuntimeError: cryptography is required for sha256_password or caching_sha2_password

```

Adding `cryptography` as dependency will fix this error.